### PR TITLE
support of external temperature sensor via mqtt and fix error on connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Homebridge EQ3BLE
-Homebridge plugin to control EQ3 bluetooth thermostats
+Homebridge plugin to control EQ3 bluetooth thermostats.
+
+It's possible to report MQTT topic's messages as current temperature of this thermostat.
 
 ### Usage
 ````json
@@ -29,7 +31,40 @@ You can configure the homebridge integration for the thermostat with the followi
 | `discoverTimeout` | `60000` | time in milliseconds before a timeout error will be triggered |
 | `connectionTimeout` | `10000` | time in milliseconds before homebridge will disconnect from the device after last action |
 | `disableBoostSwitch` | `false` | if set to true, the boost switch won't be published from homebridge |
+| `currentTemperature` |  | [MQTT configuration for current temperature](#externalcurrenttemperature) |
 
+### <a name="#externalcurrenttemperature"></a>External current temperature configuration options
+
+| Option | Description |
+| --- |  --- |
+| `url` *(required)* | MQTT URL |
+| `topic` *(required)* | MQTT Topic name |
+| `username` | Username for accessing MQTT server |
+| `password` | Password for accessing MQTT server |
+
+## Usage with external current temperature sensor
+````json
+{
+  "bridge": {
+    "name": "Homebridge",
+    "username": "CC:22:3D:E3:CE:30",
+    "port": 51826,
+    "pin": "031-45-154"
+  },
+
+  "accessories": [{
+    "accessory": "EQ3-Thermostat",
+    "name": "Bedroom Thermostat",
+    "address": "00:1a:22:07:48:77",
+    "currentTemperature": {
+      "url": "mqtt://localhost",
+      "topic": "/home/sensors/bedroom/temperature",
+      "username": "sensors",
+      "password": "Sensors!"
+    }
+  }]
+}
+````
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ You can configure the homebridge integration for the thermostat with the followi
 | `discoverTimeout` | `60000` | time in milliseconds before a timeout error will be triggered |
 | `connectionTimeout` | `10000` | time in milliseconds before homebridge will disconnect from the device after last action |
 | `disableBoostSwitch` | `false` | if set to true, the boost switch won't be published from homebridge |
-| `currentTemperature` |  | [MQTT configuration for current temperature](#externalcurrenttemperature) |
+| `currentTemperature` |  | MQTT configuration for current temperature |
 
-### <a name="#externalcurrenttemperature"></a>External current temperature configuration options
+### External current temperature configuration options
 
 | Option | Description |
 | --- |  --- |

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "babel-core": "6.18.2",
-    "eq3ble": "1.0.0"
+    "eq3ble": "1.0.0",
+    "mqtt": "^1.12.0"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",

--- a/src/thermostat.js
+++ b/src/thermostat.js
@@ -173,7 +173,6 @@ export default function createThermostat({ Service, Characteristic }) {
         fn(...args)
         this.startDisconnectTimeout()
       }, (err) => {
-        err.isError = true
         fn(...args.concat(err))
       })
     }

--- a/src/thermostat.js
+++ b/src/thermostat.js
@@ -41,18 +41,17 @@ export default function createThermostat({ Service, Characteristic }) {
           rejectUnauthorized: false,
         })
 
-        const that = this
         this.mqttClient.on('connect', () => {
-          that.mqttClient.subscribe(config.currentTemperature.topic)
+          this.mqttClient.subscribe(config.currentTemperature.topic)
         })
 
         this.mqttClient.on('message', (topic, message) => {
           const mqttData = JSON.parse(message)
           if (mqttData === null) { return null }
-          that.currentTemperature = parseFloat(mqttData)
-          that.thermostatService
-            .setCharacteristic(Characteristic.CurrentTemperature, that.currentTemperature)
-          return that.currentTemperature
+          this.currentTemperature = parseFloat(mqttData)
+          this.thermostatService
+            .setCharacteristic(Characteristic.CurrentTemperature, this.currentTemperature)
+          return this.currentTemperature
         })
       }
 
@@ -100,7 +99,9 @@ export default function createThermostat({ Service, Characteristic }) {
         .on('get', this.execAfterConnect.bind(this, this.getTargetTemperature.bind(this)))
 
 
-      this.discoverPromise = this.discover()
+      this.discoverPromise = this.discover().catch((err) => {
+        this.log(err)
+      })
     }
     discover() {
       return new Promise((resolve, reject) => {
@@ -108,7 +109,7 @@ export default function createThermostat({ Service, Characteristic }) {
         const discoverTimeout = setTimeout(() => {
           this.discoverPromise = null
           this.log(`cannot discover thermostat (${this.address})`)
-          reject(`discovering thermostat timed out (${this.address})`)
+          reject(new Error(`discovering thermostat timed out (${this.address})`))
         }, this.discoverTimeout)
         EQ3BLE.discoverByAddress(this.address, (device) => {
           clearTimeout(discoverTimeout)
@@ -118,7 +119,7 @@ export default function createThermostat({ Service, Characteristic }) {
         }, (err) => {
           this.discoverPromise = null
           this.log(`cannot discover thermostat (${this.address}): ${err}`)
-          reject(`discovering thermostat (${this.address}) resulted in error ${err}`)
+          reject(new Error(`discovering thermostat (${this.address}) resulted in error ${err}`))
         })
       })
     }
@@ -282,7 +283,7 @@ export default function createThermostat({ Service, Characteristic }) {
         case Characteristic.TargetHeatingCoolingState.COOL:
           return this.device.manualMode().then(() => callback(),
             deviceErr => callback(deviceErr))
-        default: return callback('Unsupport mode')
+        default: return callback('Unsupported mode')
       }
     }
 


### PR DESCRIPTION
Hi!

I would like to propose more improvements to this awesome plugin :)
I've noticed that the current temperature characteristic in current version has stub implementation - i.e. it just puts there the target temperature.
I was thinking of some general way to submitting the current temperature in this thermostat to the homebridge and decided to go with mqtt-submitted values. 

so, this PR contains changes which detect if configuration have additional subsconfiguration of current temperature and if yes - then connects and subscribes to configurable topic to get current temperature from there.

new configuration section is:
```
{
  "accessory": "EQ3-Thermostat",
  ...
  "currentTemperature": {
    "url": "mqtt://localhost",
    "topic": "/home/sensors/16156/temperature",
    "username": "sensors",
    "password": "GimmeSensorsYo!"
  }
}
```

if this additional section is not specified - then the plugin works as it was working before. 

Additionally, I've fixed small issue which resulted in error in homebridge logs - in case of thermostat connection timeout the isError is passed inside arguments and not as field of the object.